### PR TITLE
Adding hypertool-mcp to awesome-mcp-enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@
 
 - **[FLUJO](https://github.com/mario-andreschak/FLUJO)** - MCP hub/inspector with multi-model workflow and chat interface for complex agent workflows using MCP servers and tools. 🧪
 
+- **[Hypertool MCP](https://github.com/toolprint/hypertool-mcp)** - An MCP that let's you dynamically select tools across all your MCPs to get around tool binding limits and context overload. 📈 💰
+
 - **[Lasso MCP Gateway](https://www.lasso.security/)** - Protects every interaction with LLMs across your organization — simple, seamless, secure. 🛡️
 
 - **[MCP Context Forge](https://github.com/IBM/mcp-context-forge)** - Feature-rich MCP gateway, proxy, and registry built on FastAPI - unifies discovery, auth, rate-limiting, virtual servers, and observability. 🆓

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 - **[FLUJO](https://github.com/mario-andreschak/FLUJO)** - MCP hub/inspector with multi-model workflow and chat interface for complex agent workflows using MCP servers and tools. 🧪
 
-- **[Hypertool MCP](https://github.com/toolprint/hypertool-mcp)** - An MCP that let's you dynamically select tools across all your MCPs to get around tool binding limits and context overload. 📈 💰
+- **[Hypertool MCP](https://github.com/toolprint/hypertool-mcp)** - An MCP that let's you dynamically select tools across all your MCPs to get around tool binding limits and context overload. 🧪 🆓
 
 - **[Lasso MCP Gateway](https://www.lasso.security/)** - Protects every interaction with LLMs across your organization — simple, seamless, secure. 🛡️
 


### PR DESCRIPTION
Suggesting an addition to your registry for https://github.com/toolprint/hypertool-mcp.

This MCP enables users to get around tool binding limits and reduce context overload by vending dynamic sets of tools across all their MCPs.

### Tool Name
Hypertool MCP

### Category
Gateways

### Why should this be included?
This MCP enables users to get around tool binding limits and reduce context overload by vending dynamic sets of tools across all their MCPs.

Enterprises need this to manage tool overload for their internal MCP servers.

### Checklist
- [x] Tool is production-ready
- [x] Documentation is comprehensive
- [x] Compliance certifications are verified
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained
- [x] All links are working
- [x] Updated the count in the content section
