### PR TITLE
Add mcpcentral.io to Private Registries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Contents
 
- - [Private Registries (11)](#private-registries)
+ - [Private Registries (12)](#private-registries)
  - [Gateways & Proxies (19)](#gateways--proxies)
  - [Build Tools & Frameworks (12)](#build-tools--frameworks)
  - [Security & Governance (5)](#security--governance)
@@ -33,6 +33,9 @@
 - **[Make MCP](https://www.make.com/en)** - Integration module for connecting MCP servers to Make.com workflows. Enables workflow automations with MCP servers. 🆓
 
 - **[mcp.run](https://mcp.run)** - One platform for vertical AI across your organization. Instantly deploy MCP servers in the cloud for rapid prototyping or production use. 🛡️
+
+- **[[mcp]central.io](https://mcpcentral.io)** - Private registries, managed cloud solutions, and intelligent tooling for
+  non-technical enterprise teams, plus public directory. 🧪 🆓 🔑 🛡️
 
 - **[Pipedream](https://mcp.pipedream.com/)** - AI developer toolkit for integrations: add 2,800+ APIs and 10,000+ tools to your assistant. 🆓
 


### PR DESCRIPTION
Updated the README to include mcpcentral.io as a new entry under Private Registries, increasing the count from 11 to 12.

### Tool Name
[mcp]central.io

### Category
Private Registries

### Why should this be included?
While most MCP-related projects are positioned as development tools, [mcp]central.io serves as the cornerstone for a developing cloud-based agent ecosystem. It was designed from the start to meet the needs of companies with limited or no development teams who still require the same level of reporting, compliance, etc. as larger enterprises. The platform is built and managed by a team with over 10 years of experience providing managed cloud solutions in highly regulated industries.

### Checklist
- [x] Tool is production-ready
- [x] Documentation is comprehensive
- [x] Compliance certifications are verified
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained
- [x] All links are working
- [x] Updated the count in the content section