### PR TITLE
Replace NimbleTools with mpak in Infrastructure & Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@
 
 - **[MCPcat](https://mcpcat.io/)** - Analytics platform for MCP server owners that helps developers and product owners build, improve, and monitor their MCP servers. 🧪 🆓 
 
-- **[NimbleTools](https://www.nimbletools.ai)** - MCP runtime for the enterprise. Use our cloud or bring your own (BYOC) to securely connect AI to all your tools, APIs, and data. 🆓 
+- **[mpak](https://mpak.dev)** - Open-source MCPB registry with built-in trust framework for securely publishing, hosting, and installing MCP server bundles. 🆓 🛡️
 
 - **[Shinzo Labs](https://shinzo.ai/)** - Complete observability for MCP servers: anonymous usage analytics, error tracking, and configurable data sanitization; GDPR/CPRA-friendly with self‑hosting options. 🛡️ 🇪🇺 🆓
 


### PR DESCRIPTION
### Tool Name
mpak

### Category
Infrastructure & Deployment

### Why should this be included?
mpak is an open-source MCPB (MCP Bundle) registry with a built-in trust framework (MTF) for securely publishing, hosting, and installing self-contained MCP server bundles. It replaces the NimbleTools entry, which has been superseded by mpak.

- **Registry**: Search, publish, and install MCP server bundles at [mpak.dev](https://mpak.dev)
- **Security**: Built-in mpak Trust Framework (MTF) for bundle provenance and security verification
- **Open source**: Fully open-source registry, CLI, and SDKs

### Checklist
- [x] Tool is production-ready
- [x] Documentation is comprehensive
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained
- [x] All links are working