### PR TITLE
Add Agent Native Registry to MCP Directories & Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@
 
 - **[Smithery](https://smithery.ai/)** - Gateway to 5000+ ready-made MCP servers with one-click deployment. 🆓
 
+- **[Agent Native Registry](https://agentnativeregistry.com)** - Rating system and remote MCP server scoring 100+ developer tools on AI agent compatibility (0-100). Tools: `search_tools`, `get_score`, `compare_tools`. Evaluates account creation, agent tooling, reliability, discovery, and pricing. 🆓
+
 ## Tutorials & Guides
 *Enterprise-focused tutorials, implementation guides, and best practices for MCP deployment*
 


### PR DESCRIPTION
[Agent Native Registry](https://agentnativeregistry.com) is a rating system and remote MCP server for the MCP ecosystem.

**Why it belongs in MCP Directories & Marketplaces:**
- Rates 100+ developer tools on AI agent compatibility (0-100 scale)
- Remote MCP server at `https://agentnativeregistry.com/api/mcp`
- MCP tools: `search_tools`, `get_score`, `compare_tools`
- Scores 5 dimensions: account creation (can agents sign up?), agent tooling (SDK/MCP?), reliability, discovery (llms.txt?), pricing model

This is distinct from other directories in that it provides quantitative scores across consistent criteria — not just a list of servers.