### PR TITLE
Add Arch Tools — 61 production-ready AI tools via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
 
 - **[Zapier MCP](https://zapier.com/mcp)** - Connect your AI to any app with Zapier MCP. The fastest way to let your AI assistant interact with thousands of apps. 🧪 🆓 🇪🇺 📜
 
+- **[Arch Tools](https://archtools.dev)** - 53 production-ready AI tools via MCP with x402 USDC micropayments. Web scraping, crypto data, AI generation, OCR, DNS, WHOIS, and more. 🔑
+
 
 ## Gateways & Proxies
 *MCP gateways, proxies, and routing solutions for enterprise architectures. Most also provide security features like OAuth, authn/authz, and guardrails.*


### PR DESCRIPTION
Adds Arch Tools to the Private Registries section.

**Website:** https://archtools.dev

53 production-ready AI tools accessible via MCP with x402 USDC micropayments. Includes web scraping, crypto data, AI generation, OCR, DNS, WHOIS, and more.