### PR TITLE
Add Signet to Security & Governance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@
 
 - **[Portkey MCP Gateway](https://portkey.ai/features/mcp)** - Open-source MCP control plane with centralized auth, access control, and observability. Single gateway for teams managing multiple MCP servers. 🆓 🔑 🛡️
 
-- **[Prefactor](https://prefactor.tech/)** - Native MCP Identity Layer for Modern SaaS. Secure, authorize, and audit AI agents — not just users. 🆓 🛡️ 🇪🇺 🏥 
+- **[Prefactor](https://prefactor.tech/)** - Native MCP Identity Layer for Modern SaaS. Secure, authorize, and audit AI agents — not just users. 🆓 🛡️ 🇪🇺 🏥
+
+- **[Signet](https://github.com/Prismer-AI/signet)** - Cryptographic action receipts for AI agents. Signs every MCP tool call with Ed25519, hash-chained audit log. Client-side SigningTransport middleware — MCP servers don't need to change. Rust core + WASM + TypeScript. 🆓 📜 🛡️
 
 - **[scalekit](https://www.scalekit.com/)** - Modular auth platform for AI applications. Drop-in OAuth 2.1 specifically designed for MCP servers. 🆓 🔑 🛡️ 📜 🇪🇺 📘
 


### PR DESCRIPTION
Add [Signet](https://github.com/Prismer-AI/signet) to the Security & Governance section.

Signet gives AI agents Ed25519 cryptographic identity and signs every MCP tool call. Features:

- Client-side SigningTransport middleware (3 lines of code)
- Argon2id + XChaCha20-Poly1305 encrypted key storage
- Append-only JSONL audit log with SHA-256 hash chain
- CLI for identity management, signing, verification, and audit

Published: npm (@signet-auth/mcp, @signet-auth/core), crates.io (signet-core)
License: Apache-2.0 / MIT, 83 tests