### PR TITLE
Add EMERGING list and issue-first contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution Guide
+    url: https://github.com/bh-rat/awesome-mcp-enterprise/blob/main/CONTRIBUTING.md
+    about: Read this before proposing a tool. PRs without a pre-approved proposal issue will be closed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Contribution Guide
     url: https://github.com/bh-rat/awesome-mcp-enterprise/blob/main/CONTRIBUTING.md
-    about: Read this before proposing a tool. PRs without a pre-approved proposal issue will be closed.
+    about: Read this before proposing a listing. PRs without a pre-approved proposal issue will be closed.

--- a/.github/ISSUE_TEMPLATE/listing-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/listing-proposal.yml
@@ -1,6 +1,6 @@
-name: Tool Proposal
-description: Propose a new tool for Awesome MCP Enterprise (open this before any PR)
-title: "[Proposal] <Tool Name>"
+name: Listing Proposal
+description: Propose a new listing for Awesome MCP Enterprise (open this before any PR)
+title: "[Proposal] <Listing Name>"
 labels: ["proposal", "needs-triage"]
 body:
   - type: markdown
@@ -11,15 +11,15 @@ body:
         Do not open a PR yet. Wait for the `approved-for-pr` label.
 
   - type: input
-    id: tool-name
+    id: listing-name
     attributes:
-      label: Tool Name
+      label: Listing Name
       placeholder: e.g. Acme MCP Gateway
     validations:
       required: true
 
   - type: input
-    id: tool-url
+    id: listing-url
     attributes:
       label: Primary URL
       description: Product website or GitHub repo
@@ -105,9 +105,9 @@ body:
   - type: dropdown
     id: affiliation
     attributes:
-      label: Your affiliation with the tool
+      label: Your affiliation with this listing
       options:
-        - I work on / for this tool
+        - I work on / for this project
         - I have a financial interest (investor, advisor, contractor)
         - I am a user / customer
         - No affiliation

--- a/.github/ISSUE_TEMPLATE/tool-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/tool-proposal.yml
@@ -1,0 +1,127 @@
+name: Tool Proposal
+description: Propose a new tool for Awesome MCP Enterprise (open this before any PR)
+title: "[Proposal] <Tool Name>"
+labels: ["proposal", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) first.** Every field below is required. Proposals with missing evidence will be marked `needs-more-info` or `declined`.
+
+        Do not open a PR yet. Wait for the `approved-for-pr` label.
+
+  - type: input
+    id: tool-name
+    attributes:
+      label: Tool Name
+      placeholder: e.g. Acme MCP Gateway
+    validations:
+      required: true
+
+  - type: input
+    id: tool-url
+    attributes:
+      label: Primary URL
+      description: Product website or GitHub repo
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Target Category
+      description: Must be an existing category. We are not accepting new categories.
+      options:
+        - Private Registries
+        - Gateways & Proxies
+        - Build Tools & Frameworks
+        - Security & Governance
+        - Infrastructure & Deployment
+        - MCP Directories & Marketplaces
+        - Tutorials & Guides
+    validations:
+      required: true
+
+  - type: dropdown
+    id: list
+    attributes:
+      label: Which List
+      description: |
+        **Main** = meets 2+ of the quality bar (see CONTRIBUTING.md).
+        **Emerging** = MCP-native, enterprise-oriented, but still early — beta / recent GA / no public compliance / limited production evidence yet.
+      options:
+        - Main list (README.md)
+        - Emerging (EMERGING.md)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: One-sentence description
+      description: Exactly what will appear in the list. Must be one sentence.
+      placeholder: "Enterprise MCP gateway with OAuth, audit logging, and policy enforcement."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: quality-bar
+    attributes:
+      label: Quality Bar Evidence (Main list — check all that apply)
+      description: |
+        Main-list entries must satisfy **at least 2**. Provide links in the next field. If submitting to Emerging, you can skip this.
+      options:
+        - label: Named enterprise customers publicly listed on the product site
+        - label: Verifiable compliance (SOC 2 Type II / ISO 27001 / HIPAA / equivalent)
+        - label: GA for 6+ months (not private beta, not early access)
+        - label: Documented production deployments (customer case studies, conference talks, published references)
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence Links
+      description: |
+        Paste direct URLs backing every claim above. "Trust me" does not count.
+        Example:
+          - Customers: https://acme.com/customers
+          - SOC 2: https://trust.acme.com
+          - GA date: https://acme.com/blog/ga-announcement
+      placeholder: |
+        - Customers: https://...
+        - Compliance: https://...
+        - GA: https://...
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why should this be included?
+      description: What enterprise problem does this solve that existing entries in the category don't?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affiliation
+    attributes:
+      label: Your affiliation with the tool
+      options:
+        - I work on / for this tool
+        - I have a financial interest (investor, advisor, contractor)
+        - I am a user / customer
+        - No affiliation
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: This is MCP infrastructure, not an MCP server or agent framework
+        - label: I have read CONTRIBUTING.md
+        - label: I understand that PRs opened before this issue is labeled `approved-for-pr` will be closed
+          required: true
+        - label: All links above are live and accessible without login
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,29 @@
+<!--
+PRs without a pre-approved proposal issue will be closed.
+If you have not opened a Tool Proposal issue and received the `approved-for-pr` label, stop here and open an issue first.
+-->
+
+### Linked Proposal Issue
+Closes #<!-- issue number with the `approved-for-pr` label -->
+
 ### Tool Name
 [Tool Name]
 
-### Category
-[Select: Private Registries / Directories / Build Tools / Infrastructure / Security / Gateways]
+### Which List
+- [ ] Main list (README.md)
+- [ ] Emerging (EMERGING.md)
 
-### Why should this be included?
-[Brief explanation of why this tool is valuable for enterprises]
+### Category
+[Private Registries / Gateways & Proxies / Build Tools & Frameworks / Security & Governance / Infrastructure & Deployment / MCP Directories & Marketplaces / Tutorials & Guides]
 
 ### Checklist
+- [ ] Linked proposal issue above is labeled `approved-for-pr`
+- [ ] Entry matches the one-sentence description approved in the issue
 - [ ] This is MCP infrastructure (not an MCP server or agent framework)
-- [ ] This fits an existing category (not proposing a new section)
-- [ ] Tool is production-ready (or clearly marked as beta with 🧪)
+- [ ] Placed in the correct category
+- [ ] Alphabetical order maintained within the category
+- [ ] Entry follows the required format (see CONTRIBUTING.md)
+- [ ] Only verifiable emojis included
+- [ ] Emerging entries include 🧪
+- [ ] Updated the count in the Contents section of README.md (main-list entries only)
 - [ ] All links are live and functional
-- [ ] Documentation is comprehensive
-- [ ] Compliance certifications are verified (if claimed)
-- [ ] Entry follows the required format
-- [ ] Placed in correct category
-- [ ] Alphabetical order maintained
-- [ ] Updated the count in the contents section

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 <!--
 PRs without a pre-approved proposal issue will be closed.
-If you have not opened a Tool Proposal issue and received the `approved-for-pr` label, stop here and open an issue first.
+If you have not opened a Listing Proposal issue and received the `approved-for-pr` label, stop here and open an issue first.
 -->
 
 ### Linked Proposal Issue
 Closes #<!-- issue number with the `approved-for-pr` label -->
 
-### Tool Name
-[Tool Name]
+### Listing Name
+[Listing Name]
 
 ### Which List
 - [ ] Main list (README.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to Awesome MCP Enterprise! This guide will help you understand how to contribute effectively.
 
-> **Workflow is issue-first.** Open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs without an approved proposal will be closed.
+> **Workflow is issue-first.** Open a [Listing Proposal issue](.github/ISSUE_TEMPLATE/listing-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs without an approved proposal will be closed.
 
 ## Before You Submit
 
@@ -23,14 +23,14 @@ This repository lists **infrastructure, platforms, and services for building, ho
 - New categories. We are not adding new sections at this time.
 - Blog posts & articles (section currently paused)
 
-> **Not sure?** Open an issue first to discuss whether your tool fits before submitting a PR.
+> **Not sure?** Open an issue first to discuss whether your listing fits before submitting a PR.
 
 ### Two Lists
 
 We maintain two lists so contributors have a path in regardless of maturity stage. Placement is about evidence, not about the quality of your work.
 
 - **Main list (`README.md`)** — expected to meet **at least 2 of 4**: (1) named enterprise customers listed publicly, (2) verifiable compliance (SOC 2 / ISO 27001 / HIPAA / equivalent), (3) GA for 6+ months, (4) documented production deployments. Self-claims without links can't be verified, so please include sources.
-- **Emerging (`EMERGING.md`)** — MCP-native, enterprise-oriented tools that are still early — in beta, recently GA, or without public compliance documentation yet. Marked 🧪. Reviewed periodically; entries move to the main list as they mature.
+- **Emerging (`EMERGING.md`)** — MCP-native, enterprise-oriented projects that are still early — in beta, recently GA, or without public compliance documentation yet. Marked 🧪. Reviewed periodically; entries move to the main list as they mature.
 
 ### Required Criteria
 - **Production-Ready**: The tool/service must be in production or GA (General Availability) stage (beta tools may be accepted in Emerging if clearly marked with 🧪)
@@ -45,16 +45,16 @@ We maintain two lists so contributors have a path in regardless of maturity stag
 - Must have a working website or GitHub repository
 - Verifiable compliance certifications (if claimed)
 
-## How to Add a New Tool
+## How to Add a New Listing
 
-1. **Open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml)** — fill every field, including evidence links and which list (Main or Emerging)
+1. **Open a [Listing Proposal issue](.github/ISSUE_TEMPLATE/listing-proposal.yml)** — fill every field, including evidence links and which list (Main or Emerging)
 2. **Wait for triage** — maintainer labels the issue `approved-for-pr`, `needs-more-info`, or `declined`
 3. **Fork the repository** once approved
-4. **Add your tool to the appropriate category** in `README.md` (main) or `EMERGING.md` (emerging)
+4. **Add your listing to the appropriate category** in `README.md` (main) or `EMERGING.md` (emerging)
 5. **Follow the exact format**:
 
 ```markdown
-- **[Tool Name](https://website.com)** - One-line description focusing on unique value. 📜 🆓 🔑
+- **[Listing Name](https://website.com)** - One-line description focusing on unique value. 📜 🆓 🔑
 ```
 
 **Note:** Production stage is assumed by default. Only add 🧪 emoji for beta/non-production tools (required for all Emerging entries).
@@ -74,8 +74,8 @@ When submitting a PR, please use this template:
 ### Linked Proposal Issue
 Closes #<issue-number>  <!-- must be labeled approved-for-pr -->
 
-### Tool Name
-[Tool Name]
+### Listing Name
+[Listing Name]
 
 ### Which List
 [Main list / Emerging]
@@ -85,7 +85,7 @@ Closes #<issue-number>  <!-- must be labeled approved-for-pr -->
 
 ### Checklist
 - [ ] Linked proposal issue is labeled `approved-for-pr`
-- [ ] Tool is production-ready (or marked 🧪 for Emerging)
+- [ ] Listing is production-ready (or marked 🧪 for Emerging)
 - [ ] Documentation is comprehensive
 - [ ] Compliance certifications are verified
 - [ ] Entry follows the required format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing to Awesome MCP Enterprise! This guide will help you understand how to contribute effectively.
 
+> **Workflow is issue-first.** Open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs without an approved proposal will be closed.
+
 ## Before You Submit
 
 ### Understanding the Scope
@@ -19,11 +21,19 @@ This repository lists **infrastructure, platforms, and services for building, ho
 - Agent frameworks that consume MCP tools but don't provide MCP infrastructure
 - Badges, certifications, or branding additions to this README
 - New categories. We are not adding new sections at this time.
+- Blog posts & articles (section currently paused)
 
 > **Not sure?** Open an issue first to discuss whether your tool fits before submitting a PR.
 
+### Two Lists
+
+We maintain two lists so contributors have a path in regardless of maturity stage. Placement is about evidence, not about the quality of your work.
+
+- **Main list (`README.md`)** — expected to meet **at least 2 of 4**: (1) named enterprise customers listed publicly, (2) verifiable compliance (SOC 2 / ISO 27001 / HIPAA / equivalent), (3) GA for 6+ months, (4) documented production deployments. Self-claims without links can't be verified, so please include sources.
+- **Emerging (`EMERGING.md`)** — MCP-native, enterprise-oriented tools that are still early — in beta, recently GA, or without public compliance documentation yet. Marked 🧪. Reviewed periodically; entries move to the main list as they mature.
+
 ### Required Criteria
-- **Production-Ready**: The tool/service must be in production or GA (General Availability) stage (beta tools may be accepted if clearly marked with 🧪)
+- **Production-Ready**: The tool/service must be in production or GA (General Availability) stage (beta tools may be accepted in Emerging if clearly marked with 🧪)
 - **Actively Maintained**: Last update within 6 months, responsive to issues
 - **Clear Documentation**: Must have comprehensive documentation for enterprise deployment
 - **Working Links**: Your product website or repository must be live and functional
@@ -37,39 +47,45 @@ This repository lists **infrastructure, platforms, and services for building, ho
 
 ## How to Add a New Tool
 
-1. **Fork this repository**
-2. **Add your tool to the appropriate category** in README.md
-3. **Follow the exact format**:
+1. **Open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml)** — fill every field, including evidence links and which list (Main or Emerging)
+2. **Wait for triage** — maintainer labels the issue `approved-for-pr`, `needs-more-info`, or `declined`
+3. **Fork the repository** once approved
+4. **Add your tool to the appropriate category** in `README.md` (main) or `EMERGING.md` (emerging)
+5. **Follow the exact format**:
 
 ```markdown
 - **[Tool Name](https://website.com)** - One-line description focusing on unique value. 📜 🆓 🔑
 ```
 
-**Note:** Production stage is assumed by default. Only add 🧪 emoji for beta/non-production tools.
+**Note:** Production stage is assumed by default. Only add 🧪 emoji for beta/non-production tools (required for all Emerging entries).
 
-4. **Include appropriate emojis** from the legend (only if verified)
+6. **Include appropriate emojis** from the legend (only if verified)
    - Add emojis directly after the description
    - Include only emojis for features/certifications that are verifiable
-5. **Keep descriptions concise** - one sentence maximum
-6. **Maintain alphabetical order** within categories
-7. **Submit a Pull Request** with a clear title and description
+7. **Keep descriptions concise** - one sentence maximum
+8. **Maintain alphabetical order** within categories
+9. **Submit a Pull Request** linking the approved issue with `Closes #<issue-number>`
 
 ## Pull Request Template
 
 When submitting a PR, please use this template:
 
 ```markdown
+### Linked Proposal Issue
+Closes #<issue-number>  <!-- must be labeled approved-for-pr -->
+
 ### Tool Name
 [Tool Name]
+
+### Which List
+[Main list / Emerging]
 
 ### Category
 [Select: Private Registries / Directories / Build Tools / Infrastructure / Security / Gateways]
 
-### Why should this be included?
-[Brief explanation of why this tool is valuable for enterprises]
-
 ### Checklist
-- [ ] Tool is production-ready
+- [ ] Linked proposal issue is labeled `approved-for-pr`
+- [ ] Tool is production-ready (or marked 🧪 for Emerging)
 - [ ] Documentation is comprehensive
 - [ ] Compliance certifications are verified
 - [ ] Entry follows the required format
@@ -91,13 +107,13 @@ When adding emojis to your entry:
   - 🆓 Has Free Tier
   - 🔑 OAuth Support
   - 🛡️ Built-in Guardrails
-  - 🧪 Beta Stage (not production-ready)
-- Production stage is assumed - only add ⚠️ for beta/non-production tools
+  - 🧪 Beta Stage (not production-ready; required for Emerging entries)
+- Production stage is assumed - only add 🧪 for beta/non-production tools
 - Only include emojis for features/certifications you can verify with documentation
 
 ## Adding Resources
 
-Resources (tutorials, blog posts, etc.) should:
+The *Blog Posts & Articles* section is currently paused — do not submit entries for it. Tutorials & Guides submissions should:
 - Be high-quality and informative
 - Focus on enterprise use cases
 - Be from reputable sources
@@ -107,6 +123,8 @@ Resources (tutorials, blog posts, etc.) should:
 
 - **MCP servers or agent tools.** We list infrastructure for MCP, not MCP servers themselves.
 - **New categories.** We are not accepting new sections at this time.
+- **PRs without a pre-approved proposal issue.**
+- **Blog posts or articles** (section paused).
 - Alpha/experimental tools
 - Purely promotional content
 - Duplicate entries

--- a/EMERGING.md
+++ b/EMERGING.md
@@ -1,0 +1,47 @@
+# Emerging MCP Tools 🧪
+
+> **What is this list?** A watch-this-space catalogue of MCP-native, enterprise-oriented tools that are still early in their journey. Everything here is 🧪 by default — in beta, recently GA, or without public compliance documentation yet. The [main list](README.md) has a stricter evidence bar; this list is where newer projects live while they mature.
+
+> **How to read it:** An entry here means the project looks promising and worth watching. As with anything early-stage, evaluate carefully before depending on it in production.
+
+> **Moving to the main list:** Entries are reviewed periodically. As tools accumulate the evidence described in [CONTRIBUTING.md](CONTRIBUTING.md) — named customers, verifiable compliance, GA maturity, documented production use — they move to `README.md`. Entries that become inactive may be removed.
+
+## How to Propose an Emerging Entry
+
+Same as the main list: open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml), select **Emerging**, and wait for the `approved-for-pr` label before opening a PR. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Categories
+
+Categories mirror the main list. Add entries under the matching heading; leave a heading empty if no entries exist yet.
+
+### Private Registries
+
+*No entries yet.*
+
+### Gateways & Proxies
+
+*No entries yet.*
+
+### Build Tools & Frameworks
+
+*No entries yet.*
+
+### Security & Governance
+
+*No entries yet.*
+
+### Infrastructure & Deployment
+
+*No entries yet.*
+
+### MCP Directories & Marketplaces
+
+*No entries yet.*
+
+### Tutorials & Guides
+
+*No entries yet.*
+
+## Legend
+
+See the main [README legend](README.md#legend) for emoji meanings. All entries in this file carry an implicit 🧪.

--- a/EMERGING.md
+++ b/EMERGING.md
@@ -1,14 +1,14 @@
-# Emerging MCP Tools 🧪
+# Emerging MCP Listings 🧪
 
-> **What is this list?** A watch-this-space catalogue of MCP-native, enterprise-oriented tools that are still early in their journey. Everything here is 🧪 by default — in beta, recently GA, or without public compliance documentation yet. The [main list](README.md) has a stricter evidence bar; this list is where newer projects live while they mature.
+> **What is this list?** A watch-this-space catalogue of MCP-native, enterprise-oriented projects that are still early in their journey. Everything here is 🧪 by default — in beta, recently GA, or without public compliance documentation yet. The [main list](README.md) has a stricter evidence bar; this list is where newer projects live while they mature.
 
 > **How to read it:** An entry here means the project looks promising and worth watching. As with anything early-stage, evaluate carefully before depending on it in production.
 
-> **Moving to the main list:** Entries are reviewed periodically. As tools accumulate the evidence described in [CONTRIBUTING.md](CONTRIBUTING.md) — named customers, verifiable compliance, GA maturity, documented production use — they move to `README.md`. Entries that become inactive may be removed.
+> **Moving to the main list:** Entries are reviewed periodically. As projects accumulate the evidence described in [CONTRIBUTING.md](CONTRIBUTING.md) — named customers, verifiable compliance, GA maturity, documented production use — they move to `README.md`. Entries that become inactive may be removed.
 
 ## How to Propose an Emerging Entry
 
-Same as the main list: open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml), select **Emerging**, and wait for the `approved-for-pr` label before opening a PR. See [CONTRIBUTING.md](CONTRIBUTING.md).
+Same as the main list: open a [Listing Proposal issue](.github/ISSUE_TEMPLATE/listing-proposal.yml), select **Emerging**, and wait for the `approved-for-pr` label before opening a PR. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Categories
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 > **Scope:** This list covers **infrastructure, platforms, and services for building, hosting, running, and securing MCP servers**, not MCP servers themselves. If your product is an MCP server or an agent framework, it does not belong here. See [Contributing](CONTRIBUTING.md) for details.
 
+> **How entries are vetted:** The MCP ecosystem is young and quality varies widely, so we maintain two lists. The **main list below** requires evidence of enterprise readiness — named customers, verifiable compliance (SOC 2 / ISO 27001 / HIPAA), 6+ months GA, or documented production deployments (at least two of the four). Newer or early-stage tools live in **[EMERGING.md](EMERGING.md)** marked 🧪 while they mature. Contributors: please open a [proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Contents
 
  - [Private Registries (15)](#private-registries)
@@ -16,6 +18,7 @@
  - [Infrastructure & Deployment (8)](#infrastructure--deployment)
  - [MCP Directories & Marketplaces (8)](#mcp-directories--marketplaces)
  - [Tutorials & Guides (2)](#tutorials--guides)
+ - [Emerging Tools 🧪](EMERGING.md)
 
 ## Private Registries
 *Ready-to-use pluggable MCP server implementations where MCP servers and tools are managed by the organization. They usually come with auth, guardrails, observability and more.*
@@ -267,7 +270,7 @@ Emojis are used to indicate key features and certifications:
 
 ## Contributing
 
-Contributions are welcome! Please read our [contribution guidelines](CONTRIBUTING.md) before submitting a PR.
+Contributions are welcome, but please read our [contribution guidelines](CONTRIBUTING.md) first. **The workflow is issue-first:** open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs opened without an approved proposal issue will be closed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 > **Scope:** This list covers **infrastructure, platforms, and services for building, hosting, running, and securing MCP servers**, not MCP servers themselves. If your product is an MCP server or an agent framework, it does not belong here. See [Contributing](CONTRIBUTING.md) for details.
 
-> **How entries are vetted:** The MCP ecosystem is young and quality varies widely, so we maintain two lists. The **main list below** requires evidence of enterprise readiness — named customers, verifiable compliance (SOC 2 / ISO 27001 / HIPAA), 6+ months GA, or documented production deployments (at least two of the four). Newer or early-stage tools live in **[EMERGING.md](EMERGING.md)** marked 🧪 while they mature. Contributors: please open a [proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR — see [CONTRIBUTING.md](CONTRIBUTING.md).
-
 ## Contents
 
  - [Private Registries (15)](#private-registries)
@@ -270,7 +268,11 @@ Emojis are used to indicate key features and certifications:
 
 ## Contributing
 
-Contributions are welcome, but please read our [contribution guidelines](CONTRIBUTING.md) first. **The workflow is issue-first:** open a [Tool Proposal issue](.github/ISSUE_TEMPLATE/tool-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs opened without an approved proposal issue will be closed.
+Contributions are welcome — please read our [contribution guidelines](CONTRIBUTING.md) first.
+
+**How entries are vetted:** The MCP ecosystem is young and quality varies widely, so we maintain two lists. The **main list above** requires evidence of enterprise readiness — named customers, verifiable compliance (SOC 2 / ISO 27001 / HIPAA), 6+ months GA, or documented production deployments (at least two of the four). Newer or early-stage projects live in **[EMERGING.md](EMERGING.md)** marked 🧪 while they mature.
+
+**Workflow is issue-first:** open a [Listing Proposal issue](.github/ISSUE_TEMPLATE/listing-proposal.yml) and wait for the `approved-for-pr` label before opening a PR. PRs opened without an approved proposal issue will be closed.
 
 ## License
 


### PR DESCRIPTION
## Summary

The MCP ecosystem is young and quality varies widely, so this PR formalises how we curate the list — to keep the main README a trustworthy signal for enterprise readers while still giving newer, promising projects a home.

### What changes

- **Two lists.** The main `README.md` stays the vetted, enterprise-ready list. A new `EMERGING.md` holds MCP-native, enterprise-oriented tools that are still early — in beta, recently GA, or without public compliance documentation yet. Entries there are marked 🧪 and reviewed periodically; as they mature, they move to the main list.
- **Main-list quality bar.** Main-list entries are expected to meet at least **2 of 4**: (1) named enterprise customers listed publicly, (2) verifiable compliance (SOC 2 / ISO 27001 / HIPAA / equivalent), (3) GA for 6+ months, (4) documented production deployments.
- **Issue-first workflow.** Contributors open a `Tool Proposal` issue with evidence links, wait for the `approved-for-pr` label, then open a PR. This filters out scope/format mismatches cheaply — before anyone writes a PR — and saves back-and-forth.
- **Blog Posts & Articles section paused.** Existing guidance has been updated to reflect this.

### Files

- `CONTRIBUTING.md` — adds the two-lists explanation, quality bar, and issue-first workflow; preserves existing prose.
- `README.md` — adds a short "How entries are vetted" blockquote near the top and links to `EMERGING.md`.
- `EMERGING.md` (new) — banner, criteria, category scaffolding.
- `.github/ISSUE_TEMPLATE/tool-proposal.yml` (new) — structured proposal form (category, which list, evidence, affiliation, confirmations).
- `.github/ISSUE_TEMPLATE/config.yml` (new) — disables blank issues.
- `.github/pull_request_template.md` — now requires `Closes #<issue>` with an `approved-for-pr` labelled proposal.

## Test plan

- [x] Review the wording of CONTRIBUTING.md for tone and respectfulness to contributors
- [x] Confirm the 2-of-4 quality bar matches your intent
- [x] Verify EMERGING.md category structure mirrors README
- [ ] Open the Tool Proposal issue template in the GitHub UI after merge and confirm fields render correctly
- [ ] Decide policy for existing main-list entries that wouldn't meet the new bar (grandfather vs. audit — not addressed in this PR)

## Follow-ups (not in this PR)

- Triage the 7 open PRs against the new criteria (most likely land in Emerging)
- Optional GitHub Action to auto-comment on PRs without an approved issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)