### PR TITLE
Add click-to-mcp to Build Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
  - [Private Registries (15)](#private-registries)
  - [Gateways & Proxies (32)](#gateways--proxies)
- - [Build Tools & Frameworks (15)](#build-tools--frameworks)
+ - [Build Tools & Frameworks (16)](#build-tools--frameworks)
  - [Security & Governance (14)](#security--governance)
  - [Infrastructure & Deployment (8)](#infrastructure--deployment)
  - [MCP Directories & Marketplaces (8)](#mcp-directories--marketplaces)
@@ -123,6 +123,8 @@
 
 ## Build Tools & Frameworks
 *Frameworks and SDKs for building custom MCP servers and clients*
+
+- **[click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp)** - Auto-convert any Click/typer CLI into an MCP server. 🆓 🔑
 
 - **[ContexaAI](https://www.contexaai.com/)** - Firebase for MCP servers: build, test, debug, and deploy MCP servers with OAuth support. 🔑 🆓 🇪🇺
 


### PR DESCRIPTION
## Addition: click-to-mcp

**Category:** Build Tools & Frameworks

**Description:** Auto-convert any Click/typer CLI into an MCP server. Turns existing Python CLI tools into MCP-compatible servers with zero boilerplate — just point it at your Click app and get a fully functional MCP server.

**Repository:** https://github.com/Coding-Dev-Tools/click-to-mcp

**Why it fits:** click-to-mcp is a build tool that converts existing CLIs into MCP servers, directly serving the "Frameworks and SDKs for building custom MCP servers and clients" category. It lowers the barrier to MCP adoption by letting developers reuse their existing Click/typer CLIs without rewriting.

**Checklist:**
- [x] Entry added in alphabetical order within the Build Tools & Frameworks section
- [x] Section count updated (15 → 16)
- [x] Format matches existing entries: `- **[Name](URL)** - Description. emoji`
- [x] Not a duplicate of any existing entry
- [x] Open source and actively maintained