### PR TITLE
Add MCP Apps section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This repository lists **infrastructure, platforms, and services for building, ho
 - MCP servers themselves (e.g., "an MCP server for Slack" or "an agent with 50+ MCP tools")
 - Agent frameworks that consume MCP tools but don't provide MCP infrastructure
 - Badges, certifications, or branding additions to this README
-- New categories. We are not adding new sections at this time.
+- Contributor-proposed new categories. The category set is maintainer-curated; place listings in an existing section.
 - Blog posts & articles (section currently paused)
 
 > **Not sure?** Open an issue first to discuss whether your listing fits before submitting a PR.
@@ -81,7 +81,7 @@ Closes #<issue-number>  <!-- must be labeled approved-for-pr -->
 [Main list / Emerging]
 
 ### Category
-[Select: Private Registries / Directories / Build Tools / Infrastructure / Security / Gateways]
+[Select: Private Registries / Directories / Build Tools / MCP Apps / Infrastructure / Security / Gateways]
 
 ### Checklist
 - [ ] Linked proposal issue is labeled `approved-for-pr`
@@ -122,7 +122,7 @@ The *Blog Posts & Articles* section is currently paused — do not submit entrie
 ## What We Don't Accept
 
 - **MCP servers or agent tools.** We list infrastructure for MCP, not MCP servers themselves.
-- **New categories.** We are not accepting new sections at this time.
+- **Contributor-proposed new categories.** The category set is maintainer-curated; use an existing section.
 - **PRs without a pre-approved proposal issue.**
 - **Blog posts or articles** (section paused).
 - Alpha/experimental tools

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
  - [Private Registries (15)](#private-registries)
  - [Gateways & Proxies (32)](#gateways--proxies)
  - [Build Tools & Frameworks (15)](#build-tools--frameworks)
+ - [MCP Apps (3)](#mcp-apps)
  - [Security & Governance (14)](#security--governance)
  - [Infrastructure & Deployment (8)](#infrastructure--deployment)
  - [MCP Directories & Marketplaces (8)](#mcp-directories--marketplaces)
@@ -142,7 +143,7 @@
 
 - **[mcpadapt](https://grll.github.io/mcpadapt/)** - Unlock 650+ MCP tools in your favorite agentic framework. Manages and adapts MCP server tools into the appropriate format for each agent framework. 🧪 🆓 
 
-- **[mcp-use](https://github.com/mcp-use/mcp-use)** - Open-source toolkit to connect any LLM to any MCP server and build custom MCP agents with tool access. 🆓 
+- **[mcp-use](https://github.com/mcp-use/mcp-use)** - Open-source toolkit (by Manufact) to connect any LLM to any MCP server and build custom MCP agents with tool access. 🆓 
 
 - **[Naptha AI](https://auto-mcp.com/)** - Turn any agents, tools, or orchestrators into an MCP server in seconds; automates hosting and scaling from source or templates.
 
@@ -153,6 +154,15 @@
 - **[xmcp](https://xmcp.dev/)** - TypeScript framework for building and shipping MCP servers. Integrates with Next.js and deploys with zero config on Vercel. 🆓 🔑
 
 - **[Zuplo](http://zuplo.com/)** - API Management Platform that lets you build MCP servers, generate them from your existing APIs, secure them with policies, and handles the hosting. 🔑 📜 🆓
+
+## MCP Apps
+*Platforms and SDKs for building, shipping, and running MCP Apps — the official MCP extension for interactive, UI-rich apps that render inside MCP clients like ChatGPT and Claude*
+
+- **[Manufact](https://manufact.com/)** - MCP cloud to build, deploy, and scale MCP Apps and servers in production across ChatGPT, Claude, and other agents (formerly mcp-use; 7M+ SDK downloads). 🆓 🔑
+
+- **[MCP-UI](https://mcpui.dev/)** - Open-source SDK for interactive MCP UI components that became the basis of the official MCP Apps extension; adopted by Postman, Shopify, Hugging Face, Goose, and ElevenLabs. 🆓
+
+- **[OpenAI Apps SDK](https://developers.openai.com/apps-sdk)** - Official SDK to build interactive apps in ChatGPT on MCP; reference implementation of the MCP Apps extension. 🧪 🔑
 
 ## Security & Governance
 *Security, observability, guardrails, identity, and governance for MCP implementations*


### PR DESCRIPTION
Adds a new **MCP Apps** section (Manufact, MCP-UI, OpenAI Apps SDK) for the official MCP extension for interactive, UI-rich apps. Updates the Contents index, notes mcp-use is by Manufact, and clarifies in CONTRIBUTING.md that the category set is maintainer-curated.