### PR TITLE
Add futureagi-mcp-server and Future AGI umbrella to Build Tools and Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@
 
 - **[FastMCP](https://gofastmcp.com/)** - The fast, Pythonic way to build MCP servers and clients with comprehensive tooling. 🆓 🔑
 
+- **[futureagi-mcp-server](https://github.com/future-agi/futureagi-mcp-server)** - Official Future AGI MCP server exposing evals (50+ metrics), datasets, synthetic data, and runtime guardrails (Toxicity, Tone, Sexism, Prompt Injection, Data Privacy). Python, `uvx futureagi-mcp-server`. 🆓 🛡️
+
+- **[Future AGI](https://github.com/future-agi/future-agi)** - Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evaluation, simulation, datasets, gateway, and guardrails in one feedback loop. 🆓 🛡️
+
 - **[Golf.dev](https://golf.dev/)** - Turn your code into spec-compliant MCP servers with zero boilerplate. 🔑 🛡️ 🆓
 
 - **[Lean MCP](https://leanmcp.com/)** - Lightweight toolkit for quickly building MCP‑compliant servers without heavy dependencies. 


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed.

- traceAI: https://github.com/future-agi/traceAI
- ai-evaluation: https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- future-agi (umbrella): https://github.com/future-agi/future-agi
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section. Single-purpose diff: only README updates.