### PR TITLE
Add Magertron MCP Orchestrator to Emerging (Gateways & Proxies)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -22,6 +22,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[Arbitus](https://github.com/arbitusgateway/arbitus)** - Rust-based open-source MCP security proxy with per-agent auth (API key, JWT/OIDC, mTLS), rate limiting, payload filtering, HITL approvals, and OPA/Rego policies. 🧪 🆓 🔑 🛡️
 
+- **[Magertron MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm)** - Kubernetes-native MCP gateway and orchestrator with Envoy v3 xDS session-affinity routing, leader-elected HA, per-tool RBAC, OCSF-aligned audit logs for SIEM, and SSO/SCIM; Helm chart open-sourced under Apache 2.0. 🧪 🆓 🔑 🛡️
+
 - **[ToolRouter](https://toolrouter.com)** - MCP gateway providing access to 150+ pre-integrated tools behind a single account and API key, replacing per-provider credential management. 🧪 🔑 🆓
 
 ### Build Tools & Frameworks


### PR DESCRIPTION
Adds **Magertron MCP Orchestrator** to `EMERGING.md` under **Gateways & Proxies**.

- **URL:** https://github.com/curtismager20/magertron-mcpm
- **Site:** https://www.magertron.com
- Kubernetes-native MCP gateway/orchestrator: Envoy v3 xDS routing, leader-elected HA, per-tool RBAC, OCSF-aligned audit for SIEM, SSO/SCIM. Helm chart Apache 2.0.

**Note on duplicate proposals:** This product was proposed twice — #93 (Security & Governance) and #88 (Gateways & Proxies, with the GitHub repo). They are the same product, so this is a single consolidated entry. Placed under **Gateways & Proxies** since the product's core identity is an MCP gateway/orchestrator (its RBAC/audit/SSO are governance features of that gateway, similar to the existing Arbitus entry).

Placed in Emerging (🧪) — early-stage, self-submitted, pre-SOC 2, no GA/customer evidence yet. Entry inserted in alphabetical order; link verified live (HTTP 200).

Closes #93
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)