### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@
 
 - **[FLUJO](https://github.com/mario-andreschak/FLUJO)** - MCP hub/inspector with multi-model workflow and chat interface for complex agent workflows using MCP servers and tools. 🧪 
 
+- **[Future AGI](https://github.com/future-agi/future-agi)** - Open-source LLM and MCP gateway with OAuth, MCP security guardrails (mcpsec, PII and prompt-injection protection), per-call tracing, and automated evals to score tool and model outputs in production. 🆓 🔑 🛡️
+
 - **[Golf (Enterprise MCP Gateway)](https://golf.dev/)** - Enterprise MCP gateway for centralized control, policy enforcement, SIEM integration, and PII/prompt-injection protection. 🛡️ 🔑 💳
 
 - **[Itential MCP Server](https://www.itential.com/cloud-platform/itential-mcp-server/)** - Governance and orchestration layer connecting AI agents to enterprise network infrastructure with RBAC, audit logging, and policy enforcement. 🔑 🛡️


### PR DESCRIPTION
This PR adds Future AGI to this list in the Gateways & Proxies section.

Future AGI is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.