### PR TITLE
Add AgentX to Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@
 
 - **[Acuvity](https://acuvity.ai/)** - Acquired by Proofpoint (February 2026). Runtime AI and MCP security with agentic-workspace visibility, policy enforcement, and the open-source minibridge for MCP. 🛡️ 🆓
 
+- **[AgentX](https://agentx-core.com)** - Keyless agent firewall for MCP: wrap any server in one line of mcp.json and it blocks catastrophic tool calls (destructive SQL, SSRF, secret/PII reads, rm -rf, path traversal) before they reach the server, and keeps the agent's run alive instead of dying on the block. No API key, nothing leaves your machine. 🛡️ 🆓
+
 - **[Airlock](https://www.air-lock.ai/)** - Secure MCP gateway that connects AI agents to APIs with human-in-the-loop approval workflows, per-user authentication, observability, and budget controls for AI agent cost management. 🔑 🛡️ 🆓
 
 - **[akto](https://www.akto.io/)** - Agentic MCP Security Platform. Automatically discover MCP servers and related API endpoints, run targeted security tests, and detect misconfigurations, threats, and sensitive data exposure in real time. 🇪🇺 📜 🏥 📘 🆓 🛡️


### PR DESCRIPTION
Adds **AgentX** to the Security & Governance section.

`agentx-mcp` (`pip install agentx-security-sdk`) is a keyless agent firewall for MCP: wrap any server with one line in `mcp.json` and it deterministically blocks catastrophic tool calls (destructive SQL, SSRF, secret/PII reads, `rm -rf`, path traversal) before they reach the server, with no API key and nothing leaving the machine. It keeps the agent's run alive instead of dying on the block.

Placed alphabetically (after Acuvity), tagged security + free.

- Site + live demo: https://agentx-core.com
- PyPI: https://pypi.org/project/agentx-security-sdk/