### PR TITLE
Add Armorer Guard to Emerging (Security & Governance)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -32,6 +32,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 ### Security & Governance
 
+- **[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)** - MIT-licensed local Rust scanner and MCP proxy that wraps stdio MCP servers and inspects tool-call arguments for prompt injection, credential leakage, and risky actions before execution. 🧪 🆓 🛡️
+
 - **[Dominion Observatory](https://dominionobservatory.com)** - Behavioral trust scoring for 14,820+ MCP servers, with per-call attestation receipts, SLA monitoring, and compliance reporting to inform tool-call decisions before execution. 🧪 🆓 🛡️
 
 - **[Haldir](https://haldir.xyz)** - Guardian layer for AI agents with scoped sessions, encrypted secrets vault, immutable audit trail, and proxy mode that intercepts every MCP tool call for policy enforcement. 🧪 🆓 🛡️


### PR DESCRIPTION
Closes #108

### Listing Name
Armorer Guard

### Which List
Emerging

### Category
Security & Governance

Adds Armorer Guard — an MIT-licensed local Rust scanner and MCP proxy that wraps stdio MCP servers and inspects tool-call arguments for prompt injection, credential leakage, and risky actions before execution. In scope as MCP security/governance infrastructure (proxy at the agent/MCP boundary), same shape as existing entries like Arbitus and SidClaw. Early-stage with no public compliance/customer evidence, so placed in Emerging (🧪).

- Repo: https://github.com/ArmorerLabs/Armorer-Guard (live, MIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)