### PR TITLE
Add mcp-audit to Emerging (Security & Governance)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -36,6 +36,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[Haldir](https://haldir.xyz)** - Guardian layer for AI agents with scoped sessions, encrypted secrets vault, immutable audit trail, and proxy mode that intercepts every MCP tool call for policy enforcement. 🧪 🆓 🛡️
 
+- **[mcp-audit](https://github.com/adudley78/mcp-audit)** - Open-source CLI scanner for MCP server configurations that detects tool poisoning, credential leaks, supply-chain risks, and cross-server attack paths across major MCP clients. 🧪 🆓 🛡️
+
 - **[SidClaw](https://sidclaw.com)** - Open-source approval and audit layer that wraps MCP servers with policy evaluation, human-in-the-loop approval workflows, and hash-chain audit trails before tool execution. 🧪 🆓 🛡️
 
 - **[Signet](https://github.com/Prismer-AI/signet)** - SDK and middleware that gives agents Ed25519 identity and cryptographically signs every MCP tool call, with encrypted key storage and hash-chained audit logs. 🧪 🆓 🛡️


### PR DESCRIPTION
Closes #101

### Listing Name
mcp-audit

### Which List
Emerging

### Category
Security & Governance

Adds mcp-audit — an open-source (Apache-2.0) CLI scanner for MCP server configurations that detects tool poisoning, credential leaks, supply-chain risks, and cross-server attack paths across major MCP clients. In scope as MCP security/governance tooling (a scanner/auditor, not an MCP server). GA ~2 months with no public compliance/customer evidence yet, so placed in Emerging (🧪).

- Repo: https://github.com/adudley78/mcp-audit (live, Apache-2.0)
- Site: https://mcp-audit.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)