### PR TITLE
Add AnythingMCP to Emerging (Gateways & Proxies)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -20,6 +20,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 ### Gateways & Proxies
 
+- **[AnythingMCP](https://github.com/HelpCode-ai/anythingmcp)** - Self-hosted, open-source MCP gateway that turns any REST/SOAP/GraphQL/SQL API or MCP server into governed connectors, with OAuth2, RBAC, and full audit logging. 🧪 🆓 🔑 🛡️
+
 - **[Arbitus](https://github.com/arbitusgateway/arbitus)** - Rust-based open-source MCP security proxy with per-agent auth (API key, JWT/OIDC, mTLS), rate limiting, payload filtering, HITL approvals, and OPA/Rego policies. 🧪 🆓 🔑 🛡️
 
 - **[Magertron MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm)** - Kubernetes-native MCP gateway and orchestrator with Envoy v3 xDS session-affinity routing, leader-elected HA, per-tool RBAC, OCSF-aligned audit logs for SIEM, and SSO/SCIM; Helm chart open-sourced under Apache 2.0. 🧪 🆓 🔑 🛡️


### PR DESCRIPTION
Closes #106

### Listing Name
AnythingMCP

### Which List
Emerging (proposal requested Main list — see note below)

### Category
Gateways & Proxies

Adds AnythingMCP — a self-hosted, open-source (AGPL-3.0) MCP gateway that turns any REST/SOAP/GraphQL/SQL API or MCP server into governed connectors, with OAuth2, RBAC, and full audit logging. Clearly in scope as MCP infrastructure (a gateway), alongside MCP Context Forge, MetaMCP, MintMCP.

**Placed in Emerging rather than Main:** the main-list bar needs ≥2 of 4 with public, verifiable evidence. Currently none are met verifiably — the referenced German industrial group is unnamed, no SOC 2/ISO 27001/HIPAA cert, and v0.3.0 is only days old (fails GA 6+ months). Emerging is the right home today; can be promoted once 2 of the four are publicly verifiable.

- Repo: https://github.com/HelpCode-ai/anythingmcp (live, AGPL-3.0)
- Site: https://anythingmcp.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)