### PR TITLE
Add Clay Seal to Emerging (Security & Governance)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -38,6 +38,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)** - MIT-licensed local Rust scanner and MCP proxy that wraps stdio MCP servers and inspects tool-call arguments for prompt injection, credential leakage, and risky actions before execution. 🧪 🆓 🛡️
 
+- **[Clay Seal](https://github.com/clayseal/clayseal-identity)** - Attested agent identity and Biscuit capability tokens sender-constrained to a holder key, letting an MCP server authorize each tool call offline and rendering a copied token inert; Python guard and JavaScript verifier. 🧪 🆓 🛡️
+
 - **[Dominion Observatory](https://dominionobservatory.com)** - Behavioral trust scoring for 14,820+ MCP servers, with per-call attestation receipts, SLA monitoring, and compliance reporting to inform tool-call decisions before execution. 🧪 🆓 🛡️
 
 - **[Haldir](https://haldir.xyz)** - Guardian layer for AI agents with scoped sessions, encrypted secrets vault, immutable audit trail, and proxy mode that intercepts every MCP tool call for policy enforcement. 🧪 🆓 🛡️


### PR DESCRIPTION
### Linked Proposal Issue
Closes #120

### Listing Name
Clay Seal

### Which List
Emerging

### Category
Security & Governance

### Entry
```
- **[Clay Seal](https://github.com/clayseal/clayseal-identity)** - Attested agent identity and Biscuit capability tokens sender-constrained to a holder key, letting an MCP server authorize each tool call offline and rendering a copied token inert; Python guard and JavaScript verifier. 🧪 🆓 🛡️
```

### Verification
- Repo, PyPI (`clayseal-identity` 0.6.1), and npm (`@clayseal/verify` 0.1.0) all live; MIT.
- Test suite run locally: **355 passing, 90% coverage**; cross-language parity fixtures (Python mints → JS verifies) **10/10**, covering the security properties claimed — proof-of-possession required, attenuated tokens held to narrowed rights, proofs single-use and endpoint-pinned.
- No hand-rolled crypto: Biscuit, SPIFFE JWT-SVID, RFC 7638 thumbprints, DPoP-shaped proofs.
- Enforcement runs on the MCP request path (`integrations/mcp_server.py`, `integrations/mcp.py`), which is what distinguishes it from Signet's post-hoc verification.

Description deliberately avoids "capability tokens with offline attenuation" — that framing also describes the existing Signet entry. It leads on sender-constraint instead.

### Checklist
- [x] Linked proposal issue
- [x] Marked 🧪 for Emerging
- [x] Documentation is comprehensive
- [x] Only verifiable emoji claims (no compliance certs claimed)
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained (Armorer Guard → **Clay Seal** → Dominion Observatory)
- [x] All links working

🤖 Generated with [Claude Code](https://claude.com/claude-code)