### PR TITLE
Add Find MCP to Emerging (MCP Directories & Marketplaces)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -60,6 +60,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[Clarvia](https://clarvia.art)** - MCP directory and quality scanner indexing 27,000+ servers, each ranked by an AEO score covering agent-readiness, discoverability, and API quality. 🧪 🆓
 
+- **[Find MCP](https://catalog.agentage.io/mcp)** - Directory of 17,000+ MCP servers synced from the official MCP registry, queryable by agents over MCP (`mcp_search`, `mcp_get`, `mcp_categories`) via hosted Streamable HTTP or npx stdio. 🧪 🆓
+
 - **[Not Human Search](https://nothumansearch.ai)** - Agent-first search engine indexing 8,000+ MCP servers and agentically-readable sites, ranked by agentic readiness across 7 signals; includes a `verify_mcp` JSON-RPC probe. 🧪 🆓
 
 ### Tutorials & Guides


### PR DESCRIPTION
### Linked Proposal Issue
Closes #122

### Listing Name
Find MCP

### Which List
Emerging

### Category
MCP Directories & Marketplaces

### Entry
```
- **[Find MCP](https://catalog.agentage.io/mcp)** - Directory of 17,000+ MCP servers synced from the official MCP registry, queryable by agents over MCP (`mcp_search`, `mcp_get`, `mcp_categories`) via hosted Streamable HTTP or npx stdio. 🧪 🆓
```

### Verification
- **"17,000+" independently corroborated.** Paginating the full official registry (544 pages, 54,327 version rows) yields **17,433 unique server names**; the catalog UI reports 17,345. Agreement within 0.5%.
- **"Synced from the official registry" is genuine, not a scrape.** Catalog slugs derive from official reverse-DNS namespaces, and `mcp_get` returns registry payloads verbatim — OCI identifiers, transport types, `environment_variables` schemas — which a GitHub scrape cannot produce.
- Registry entry `io.agentage/find-mcp` v1.0.1 exists, `status: active`.
- Remote endpoint live and unauthenticated; tools correctly annotated `readOnlyHint: true`, `destructiveHint: false`. MIT.

### Scope note
This is queryable over MCP, but it is listed as a **directory**, consistent with Not Human Search which likewise serves its index over an MCP endpoint. The test applied: what a thing *indexes* decides the category, not what protocol it speaks — indexing the MCP ecosystem is directory infrastructure; indexing a third-party system (Jira, Postgres) would be an MCP server and out of scope. Description is worded as a directory accordingly.

### Checklist
- [x] Linked proposal issue
- [x] Marked 🧪 for Emerging
- [x] Documentation is comprehensive
- [x] Only verifiable emoji claims (no compliance certs claimed)
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained (Clarvia → **Find MCP** → Not Human Search)
- [x] All links working

🤖 Generated with [Claude Code](https://claude.com/claude-code)