### PR TITLE
Remove Clarvia from Emerging (dead link, service shut down)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -58,8 +58,6 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[AgentRank](https://agentrank-ai.com)** - Live-scored directory of 25,000+ MCP servers, ranked daily by GitHub maintenance signals (freshness, issue health, contributors, dependents, stars). 🧪 🆓
 
-- **[Clarvia](https://clarvia.art)** - MCP directory and quality scanner indexing 27,000+ servers, each ranked by an AEO score covering agent-readiness, discoverability, and API quality. 🧪 🆓
-
 - **[Find MCP](https://catalog.agentage.io/mcp)** - Directory of 17,000+ MCP servers synced from the official MCP registry, queryable by agents over MCP (`mcp_search`, `mcp_get`, `mcp_categories`) via hosted Streamable HTTP or npx stdio. 🧪 🆓
 
 - **[Not Human Search](https://nothumansearch.ai)** - Agent-first search engine indexing 8,000+ MCP servers and agentically-readable sites, ranked by agentic readiness across 7 signals; includes a `verify_mcp` JSON-RPC probe. 🧪 🆓


### PR DESCRIPTION
Removes the **Clarvia** entry from `EMERGING.md` → MCP Directories & Marketplaces. The service has been shut down by its owner and no successor exists.

### Evidence

| Asset | State |
|---|---|
| `https://clarvia.art` | **HTTP 404** — Vercel `DEPLOYMENT_NOT_FOUND` on every path (`/`, `/api`, `/api/health`, `/api/servers`, `/mcp`) |
| `https://clarvia-api.onrender.com` (backing API) | **HTTP 503** — `"This service has been suspended by its owner"` |
| `github.com/clarvia-project/scanner` | **404** (repo cited by npm, Glama, and the MCP registry) |
| `github.com/clarvia-project/clarvia-aeo-check` | **404** |
| org `clarvia-project` | exists, **0 public repos** |
| `www.clarvia.art` | does not connect |
| web.archive.org / archive.today | **zero snapshots, ever** |

Both halves of the stack are down by deliberate owner action — a suspended Render service and a deleted Vercel deployment is a teardown, not an outage or a lapsed domain.

### Not a relocation
Checked `clarvia.com/.co/.io/.dev/.ai/.tech/.org/.xyz/.app` and `getclarvia.com`: all are either parked, for sale, or unrelated products (an expat finance app, a Turkish voice-analytics product, a bereavement-workflow service, an AI consultancy). No shutdown or rebrand announcement anywhere, and the "AEO score" concept has not resurfaced under another name.

### Timeline
npm `clarvia-mcp-server` published 20 versions between 2026-03-25 and 2026-04-01, then nothing for ~3.5 months. The package is still on npm but is inert, since its only backend is suspended. The MCP registry entry `io.github.digitamaz/clarvia` still reads "active" but is frozen at 1.1.2 (2026-03-28) and points at the 404 repo — stale metadata, not a sign of life.

Per CONTRIBUTING.md, broken/dead links are not accepted, and EMERGING.md states that entries which become inactive may be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)