### PR TITLE
Update mcp-use description + add Manufact to Infrastructure & Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
  - [Private Registries (15)](#private-registries)
  - [Gateways & Proxies (33)](#gateways--proxies)
  - [Build Tools & Frameworks (17)](#build-tools--frameworks)
- - [MCP Apps (3)](#mcp-apps)
+ - [MCP Apps (2)](#mcp-apps)
  - [Security & Governance (19)](#security--governance)
- - [Infrastructure & Deployment (8)](#infrastructure--deployment)
+ - [Infrastructure & Deployment (9)](#infrastructure--deployment)
  - [MCP Directories & Marketplaces (8)](#mcp-directories--marketplaces)
  - [Tutorials & Guides (2)](#tutorials--guides)
  - [Emerging Tools 🧪](EMERGING.md)
@@ -163,8 +163,6 @@
 
 ## MCP Apps
 *Platforms and SDKs for building, shipping, and running MCP Apps — the official MCP extension for interactive, UI-rich apps that render inside MCP clients like ChatGPT and Claude*
-
-- **[Manufact](https://manufact.com/)** - MCP cloud to build, deploy, and scale MCP Apps and servers in production across ChatGPT, Claude, and other agents (formerly mcp-use; 7M+ SDK downloads). 🆓 🔑
 
 - **[MCP-UI](https://mcpui.dev/)** - Open-source SDK for interactive MCP UI components that became the basis of the official MCP Apps extension; adopted by Postman, Shopify, Hugging Face, Goose, and ElevenLabs. 🆓
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@
 
 - **[FastMCP Cloud](https://www.fastmcp.cloud/)** - Hosted FastMCP deployment to go from code to production quickly. 🧪 🔑 🆓
 
+- **[Manufact](https://manufact.com/)** - MCP cloud for deploying, hosting, and scaling MCP servers in production ("like Vercel, but for MCP"). Push-to-deploy from GitHub with per-PR preview deployments, cloud inspector, cross-client testing, publishing checks, and built-in analytics, session replay, and traces. 🆓 🔑
+
 - **[MCPcat](https://mcpcat.io/)** - Analytics platform for MCP server owners that helps developers and product owners build, improve, and monitor their MCP servers. 🧪 🆓 
 
 - **[mpak](https://mpak.dev)** - Open-source MCPB registry with built-in trust framework for securely publishing, hosting, and installing MCP server bundles. 🆓 🛡️

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
 
 - **[mcpadapt](https://grll.github.io/mcpadapt/)** - Unlock 650+ MCP tools in your favorite agentic framework. Manages and adapts MCP server tools into the appropriate format for each agent framework. 🧪 🆓 
 
-- **[mcp-use](https://github.com/mcp-use/mcp-use)** - Open-source toolkit (by Manufact) to connect any LLM to any MCP server and build custom MCP agents with tool access. 🆓
+- **[mcp-use](https://github.com/mcp-use/mcp-use)** - Open-source fullstack MCP framework (by Manufact) to build MCP Apps for ChatGPT / Claude and MCP servers for AI agents. 🆓
 
 - **[Naptha AI](https://auto-mcp.com/)** - Turn any agents, tools, or orchestrators into an MCP server in seconds; automates hosting and scaling from source or templates.
 


### PR DESCRIPTION
Two related changes for the Manufact team.

## 1. Correct the existing mcp-use description (*Build Tools & Frameworks*)

**Before:** Open-source toolkit (by Manufact) to connect any LLM to any MCP server and build custom MCP agents with tool access.
**After:** Open-source fullstack MCP framework (by Manufact) to build MCP Apps for ChatGPT / Claude and MCP servers for AI agents.

The old text describes mcp-use's earlier "connect any LLM to any MCP server" positioning. It's now a fullstack MCP framework (TypeScript + Python SDKs, CLI, inspector) for building both MCP servers for agents and MCP Apps that render inside ChatGPT and Claude.

## 2. Single Manufact listing under *Infrastructure & Deployment*

Per your feedback, I removed the existing Manufact entry from *MCP Apps* and kept **one** Manufact listing, under Infrastructure & Deployment:

> **[Manufact](https://manufact.com/)** - MCP cloud for deploying, hosting, and scaling MCP servers in production ("like Vercel, but for MCP"). Push-to-deploy from GitHub with per-PR preview deployments, cloud inspector, cross-client testing, publishing checks, and built-in analytics, session replay, and traces. 🆓 🔑

Contents counts updated accordingly (MCP Apps 3→2, Infrastructure & Deployment 8→9).

**Enterprise-readiness evidence** (per the contribution guidelines):
- Named production users across startups to enterprises, including NASA, NVIDIA, and SAP.
- Documented production deployments in finance, insurance, and marketplace use cases.
- The underlying framework (mcp-use) is listed as a recommended deployment option in OpenAI's official developer docs; ~10k GitHub stars, 7M+ SDK downloads.