### PR TITLE
Update SidClaw link to point at the GitHub repo

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -46,7 +46,7 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[mcp-audit](https://github.com/adudley78/mcp-audit)** - Open-source CLI scanner for MCP server configurations that detects tool poisoning, credential leaks, supply-chain risks, and cross-server attack paths across major MCP clients. 🧪 🆓 🛡️
 
-- **[SidClaw](https://sidclaw.com)** - Open-source approval and audit layer that wraps MCP servers with policy evaluation, human-in-the-loop approval workflows, and hash-chain audit trails before tool execution. 🧪 🆓 🛡️
+- **[SidClaw](https://github.com/sidclawhq/platform)** - Open-source approval and audit layer that wraps MCP servers with policy evaluation, human-in-the-loop approval workflows, and hash-chain audit trails before tool execution. 🧪 🆓 🛡️
 
 - **[Signet](https://github.com/Prismer-AI/signet)** - SDK and middleware that gives agents Ed25519 identity and cryptographically signs every MCP tool call, with encrypted key storage and hash-chained audit logs. 🧪 🆓 🛡️
 


### PR DESCRIPTION
Small fix to the existing SidClaw entry in EMERGING.md (Security & Governance): the link currently points at the marketing site, while the other entries in the section link to their repositories. This updates it to https://github.com/sidclawhq/platform (Apache-2.0 SDK + FSL platform, source of the open-source claim in the description). No description changes.