### PR TITLE
Add llmtrim to Emerging (Gateways & Proxies)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -24,6 +24,8 @@ Categories mirror the main list. Add entries under the matching heading; leave a
 
 - **[Arbitus](https://github.com/arbitusgateway/arbitus)** - Rust-based open-source MCP security proxy with per-agent auth (API key, JWT/OIDC, mTLS), rate limiting, payload filtering, HITL approvals, and OPA/Rego policies. 🧪 🆓 🔑 🛡️
 
+- **[llmtrim](https://github.com/fkiene/llmtrim)** - Local proxy that compresses MCP tool output, prompts, and conversation history before they reach the model, with a quality gate that reverts any step that does not save tokens. 🧪 🆓
+
 - **[Magertron MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm)** - Kubernetes-native MCP gateway and orchestrator with Envoy v3 xDS session-affinity routing, leader-elected HA, per-tool RBAC, OCSF-aligned audit logs for SIEM, and SSO/SCIM; Helm chart open-sourced under Apache 2.0. 🧪 🆓 🔑 🛡️
 
 - **[PolicyLayer](https://policylayer.com)** - Hosted MCP gateway that applies deterministic, deny-by-default policy to every tool call — allow, deny, rate-limit, or require approval — with argument-level rules, per-identity scoped tokens, and a per-call audit log. 🧪 🛡️ 🔑


### PR DESCRIPTION
### Linked Proposal Issue
Closes #107

### Listing Name
llmtrim

### Which List
Emerging

### Category
Gateways & Proxies

### Notes
Local MPL-2.0 proxy that compresses MCP tool output, prompts, and conversation history, with a quality gate that reverts any step that does not save tokens. Also ships an MCP server (`llmtrim mcp`) and embeddable libraries.

Placed in Emerging rather than the main list: no named enterprise customers, no compliance certifications, no company behind it, single maintainer. The proposer checked none of the four main-list criteria and said so in the issue.

### Checklist
- [x] Listing is production-ready (or marked 🧪 for Emerging)
- [x] Documentation is comprehensive
- [x] Compliance certifications are verified (none claimed)
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained
- [x] All links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)