### PR TITLE
Add Cloudflare MCP Server Portals to Gateways & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Contents
 
  - [Private Registries (15)](#private-registries)
- - [Gateways & Proxies (33)](#gateways--proxies)
+ - [Gateways & Proxies (34)](#gateways--proxies)
  - [Build Tools & Frameworks (17)](#build-tools--frameworks)
  - [MCP Apps (2)](#mcp-apps)
  - [Security & Governance (19)](#security--governance)
@@ -66,6 +66,8 @@
 - **[catie-mcp](https://www.catiemcp.com/)** - Context-aware, configurable proxy for routing MCP JSON-RPC requests to appropriate backends based on request content. 🧪
 
  - **[Cloud MCP](https://cloudmcp.dev/)** - Enterprise MCP control plane providing secure, scalable infrastructure and granular access control. 🧪 🔑 🛡️ 📜 🇪🇺 🆓
+
+- **[Cloudflare MCP Server Portals](https://developers.cloudflare.com/cloudflare-one/access-controls/ai-controls/mcp-portals/)** - Zero Trust gateway that centralizes up to 40 MCP servers behind a single authenticated endpoint, with Access identity, per-tool allowlists and aliases, and request-level logging. 🔑 🛡️
 
 - **[Docker MCP Gateway](https://github.com/docker/mcp-gateway)** - Open-source MCP gateway with container isolation, secrets management, and signature verification. Included in Docker Desktop. 🆓 🔑
 


### PR DESCRIPTION
### Listing Name
Cloudflare MCP Server Portals

### Which List
Main

### Category
Gateways & Proxies

### Notes
Cloudflare One / Zero Trust product that centralizes multiple MCP servers behind one authenticated endpoint. Documented as GA, supports up to 40 MCP servers per portal, Access identity with per-server OAuth, per-tool allowlists and aliases, request-level logging, optional Gateway routing for DLP inspection, plus Terraform and management APIs.

Added as a second Cloudflare entry rather than rewriting the existing one. Cloudflare Agents (Infrastructure & Deployment) is the platform for building and hosting MCP servers; MCP Server Portals is a Zero Trust gateway in front of servers you already run. Different category and different product line, consistent with how Golf appears in both Build Tools and Gateways.

Emojis kept to 🔑 🛡️ to match the existing Cloudflare Agents entry rather than inheriting Cloudflare's platform-level certifications.

Contents count updated from 33 to 34, verified against the actual entry count in the section.

### Checklist
- [x] Listing is production-ready
- [x] Documentation is comprehensive
- [x] Compliance certifications are verified (none claimed beyond auth/guardrails)
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained (between Cloud MCP and Docker MCP Gateway)
- [x] All links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)