### PR TITLE
Add Azure API Management to Gateways & Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Contents
 
  - [Private Registries (15)](#private-registries)
- - [Gateways & Proxies (34)](#gateways--proxies)
+ - [Gateways & Proxies (35)](#gateways--proxies)
  - [Build Tools & Frameworks (17)](#build-tools--frameworks)
  - [MCP Apps (2)](#mcp-apps)
  - [Security & Governance (19)](#security--governance)
@@ -60,6 +60,8 @@
 - **[agentgateway](https://agentgateway.dev/)** - Open-source, AI-native data plane for MCP and A2A in the Linux Foundation, with an enterprise distribution for security, observability, and governance at scale. 🆓 🔑 🛡️
 
 - **[Arcade.dev](https://www.arcade.dev)** - AI Tool-calling Platform that securely connects AI to MCPs, APIs, data, and more. Build assistants that don't just chat – they get work done. 🔑 🆓 📜 🏥 💳
+
+- **[Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/secure-mcp-servers)** - Exposes existing APIs as MCP servers and governs external MCP runtimes, implementing the MCP authorization spec (OAuth 2.1 and Protected Resource Metadata) with Entra ID identity. 🧪 🔑 🛡️
 
 - **[Bifrost](https://github.com/maximhq/bifrost)** - High-performance open-source LLM and MCP gateway with sub-100µs overhead. Unified API for 15+ providers with automatic fallbacks and load balancing. 🆓
 


### PR DESCRIPTION
### Listing Name
Azure API Management

### Which List
Main

### Category
Gateways & Proxies

### Notes
Single control plane for exposing and governing MCP capabilities from REST APIs, Azure-hosted services, or external MCP-compliant runtimes (Logic Apps, Azure Functions, LangChain, custom). Speaks the MCP authorization spec built on OAuth 2.1 and Protected Resource Metadata (RFC 9728), with Entra ID token validation.

Marked 🧪 because MCP support on the v2 SKUs (Basic v2, Standard v2, Premium v2) is public preview. It shipped earlier on the classic tiers.

### Checklist
- [x] Listing is production-ready (marked 🧪 for preview MCP support)
- [x] Documentation is comprehensive
- [x] Compliance certifications are verified (none claimed beyond auth/guardrails)
- [x] Entry follows the required format
- [x] Placed in correct category
- [x] Alphabetical order maintained (between Arcade.dev and Bifrost)
- [x] All links are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)